### PR TITLE
resize help screen to fit the screen

### DIFF
--- a/src/css/terminal7.css
+++ b/src/css/terminal7.css
@@ -500,6 +500,8 @@ td {
 #help-home, #help-gate {
     visibility: hidden;
     opacity: 0;
+    display: flex;
+    max-height: calc(100% - 56px);
     position: fixed;
     left: 0;
     bottom: 56px;


### PR DESCRIPTION
Fixes: https://github.com/tuzig/terminal7/issues/139

But, the image is stretched when the screen is large.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#139: Help screen should be resized to fit the screen](https://issuehunt.io/repos/256925027/issues/139)
---
</details>
<!-- /Issuehunt content-->