### PR TITLE
Support for minimum pane size, close #177

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -46,6 +46,7 @@ export class Cell {
         }
         this.w.activeP = this
         this.e.style.borderColor = FOCUSED_BORDER_COLOR
+        this.w.toggleDivideButtons()
     }
     /*
      * Used to grow/shrink the terminal based on containing element dimensions

--- a/src/layout.js
+++ b/src/layout.js
@@ -297,25 +297,23 @@ export class Layout extends Cell {
             this.layout && this.layout.moveBorder(this, border, dest)
             return
         }
-        let max = this.w.rootLayout.unfold().filter(c => c !== p1).sort((a, b) => a.xoff - b.xoff).find(c => c[off] >= p1[off])
-        dest = Math.max(dest, p0[off])
-        if (p1[s] > 0.001)
-            dest = Math.min(dest, max?.[off] || 1) 
+        let max = this.findNext(p1)
+        dest = Math.max(dest, p0[off] + 0.02)
+        dest = Math.min(dest, (max?.[off] || 1) - 0.02)
         let by = p1[off] - dest
         p0[s] -= by
         p1[s] += by
         p1[off] = dest
         p0.refreshDividers()
         p1.refreshDividers()
+        this.w.toggleDivideButtons()
     }
-    unfold() {
-        let cells = []
-        for (const cell of this.cells) {
-            if (cell instanceof Layout)
-                cells.push(...cell.unfold())
-            else
-                cells.push(cell)
-        }
-        return cells
+    findNext(c) {
+        if (this.nextCell(c))
+            return this.nextCell(c)
+        let root = this.layout?.layout
+        if (root)
+            return root.findNext(this.layout)
+        return null
     }
 }

--- a/src/layout.js
+++ b/src/layout.js
@@ -297,12 +297,25 @@ export class Layout extends Cell {
             this.layout && this.layout.moveBorder(this, border, dest)
             return
         }
-
+        let max = this.w.rootLayout.unfold().filter(c => c !== p1).sort((a, b) => a.xoff - b.xoff).find(c => c[off] >= p1[off])
+        dest = Math.max(dest, p0[off])
+        if (p1[s] > 0.001)
+            dest = Math.min(dest, max?.[off] || 1) 
         let by = p1[off] - dest
         p0[s] -= by
         p1[s] += by
         p1[off] = dest
         p0.refreshDividers()
         p1.refreshDividers()
+    }
+    unfold() {
+        let cells = []
+        for (const cell of this.cells) {
+            if (cell instanceof Layout)
+                cells.push(...cell.unfold())
+            else
+                cells.push(cell)
+        }
+        return cells
     }
 }

--- a/src/terminal7.js
+++ b/src/terminal7.js
@@ -142,11 +142,11 @@ export class Terminal7 {
                 e.addEventListener("click", ev => this.clear()))
         document.getElementById("divide-h")
                 .addEventListener("click", ev =>  {
-                    if (this.activeG)
+                    if (this.activeG && this.activeG.activeW.activeP.sy >= 0.04)
                         this.activeG.activeW.activeP.split("rightleft", 0.5)})
         document.getElementById("divide-v")
                 .addEventListener("click", ev =>  {
-                    if (this.activeG)
+                    if (this.activeG && this.activeG.activeW.activeP.sx >= 0.04)
                         this.activeG.activeW.activeP.split("topbottom", 0.5)})
         let addHost = document.getElementById("add-host")
         document.getElementById('add-static-host').addEventListener(

--- a/src/terminal7.js
+++ b/src/terminal7.js
@@ -1056,10 +1056,24 @@ peer_name = "${peername}"\n`
 
         if (this.gesture) {
             let where = this.gesture.where,
-                dest = Math.min(1.0, (where == "top")
-                        ? y / document.body.offsetHeight
-                        : x / document.body.offsetWidth)
-            this.gesture.pane.layout.moveBorder(this.gesture.pane, where, dest)
+                pane = this.gesture.pane,
+                dest, cells, i,  min, max
+            if (where == "left" || where == "right") {
+                dest = x / document.body.offsetWidth
+                cells = this.cells.filter(c => c.constructor.name == 'Pane' && (c.xoff != pane.xoff || c == pane)).sort((a, b) => a.xoff - b.xoff)
+                i = cells.indexOf(pane)
+                min = cells[i - 1]?.xoff || 0
+                max = cells[i + 1]?.xoff || 1
+            } else {
+                dest = y / (document.querySelector('.windows-container').offsetHeight)
+                cells = this.cells.filter(c => c.constructor.name == 'Pane' && (c.yoff != pane.yoff || c == pane)).sort((a, b) => a.yoff - b.yoff)
+                i = cells.indexOf(pane)
+                min = cells[i - 1]?.yoff || 0
+                max = cells[i + 1]?.yoff || 1
+            }
+            dest = Math.max(dest, min)
+            dest = Math.min(dest, max)
+            pane.layout.moveBorder(pane, where, dest)
             ev.stopPropagation()
             ev.preventDefault()
         }

--- a/src/terminal7.js
+++ b/src/terminal7.js
@@ -1056,24 +1056,10 @@ peer_name = "${peername}"\n`
 
         if (this.gesture) {
             let where = this.gesture.where,
-                pane = this.gesture.pane,
-                dest, cells, i,  min, max
-            if (where == "left" || where == "right") {
-                dest = x / document.body.offsetWidth
-                cells = this.cells.filter(c => c.constructor.name == 'Pane' && (c.xoff != pane.xoff || c == pane)).sort((a, b) => a.xoff - b.xoff)
-                i = cells.indexOf(pane)
-                min = cells[i - 1]?.xoff || 0
-                max = cells[i + 1]?.xoff || 1
-            } else {
-                dest = y / (document.querySelector('.windows-container').offsetHeight)
-                cells = this.cells.filter(c => c.constructor.name == 'Pane' && (c.yoff != pane.yoff || c == pane)).sort((a, b) => a.yoff - b.yoff)
-                i = cells.indexOf(pane)
-                min = cells[i - 1]?.yoff || 0
-                max = cells[i + 1]?.yoff || 1
-            }
-            dest = Math.max(dest, min)
-            dest = Math.min(dest, max)
-            pane.layout.moveBorder(pane, where, dest)
+                dest = Math.min(1.0, (where == "top")
+                    ? y / document.querySelector('.windows-container').offsetHeight
+                    : x / document.body.offsetWidth)
+            this.gesture.pane.layout.moveBorder(this.gesture.pane, where, dest)
             ev.stopPropagation()
             ev.preventDefault()
         }

--- a/src/window.js
+++ b/src/window.js
@@ -204,4 +204,16 @@ export class Window {
             this.gate.sendState()
         }
     }
+    toggleDivideButtons() {
+        let bV = document.getElementById("divide-v")
+        let bH = document.getElementById("divide-h")
+        if (this.activeP.sx < 0.04)
+            bV.classList.add("off")
+        else
+            bV.classList.remove("off")
+        if (this.activeP.sy < 0.04)
+            bH.classList.add("off")
+        else
+            bH.classList.remove("off")
+    }
 }

--- a/tests/infra.ts
+++ b/tests/infra.ts
@@ -81,6 +81,8 @@ export class Terminal7Mock extends Terminal7 {
           </nav>
        </div>
     </template>
+    <div id="divide-v"></div>
+    <div id="divide-h"></div>
 `
 
     }


### PR DESCRIPTION
Initial support for minimum pane size, also disabling the split buttons if the focused pane is too small to split.
The current minimum is 0.02 (2%) but that can be changed. I think adding a new config entry of min_pane_size might also work.