### PR TITLE
Changing the URL and HTML title

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -47,12 +47,8 @@ export class Cell {
         this.w.activeP = this
         this.e.style.borderColor = FOCUSED_BORDER_COLOR
         this.w.toggleDivideButtons()
-        setTimeout(() =>
-            window.location.href =
-            `#${this.gate.name}.${this.w.id + 1}.${this.w.t7.cells
-                .filter(c => c.w == this.w && c.e.className == "cell pane")
-                .indexOf(this) + 1}`
-        )
+        setTimeout(() => window.location.href = `#pane-${this.id}`)
+        this.w.nameE.setAttribute("href", `#pane-${this.id}`)
     }
     /*
      * Used to grow/shrink the terminal based on containing element dimensions

--- a/src/cell.js
+++ b/src/cell.js
@@ -47,6 +47,12 @@ export class Cell {
         this.w.activeP = this
         this.e.style.borderColor = FOCUSED_BORDER_COLOR
         this.w.toggleDivideButtons()
+        setTimeout(() =>
+            window.location.href =
+            `#${this.gate.name}.${this.w.id + 1}.${this.w.t7.cells
+                .filter(c => c.w == this.w && c.e.className == "cell pane")
+                .indexOf(this) + 1}`
+        )
     }
     /*
      * Used to grow/shrink the terminal based on containing element dimensions

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -350,6 +350,7 @@ echo "${fp}" >> ~/.config/webexec/authorized_fingerprints
                 if (w.active) 
                     this.activeW = win
                 win.restoreLayout(w.layout)
+                win.nameE?.setAttribute("href", `#pane-${win.activeP?.id}`)
             })
         }
 

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -252,6 +252,7 @@ export class Gate {
         // do nothing when the network is down
         if (!this.t7.netStatus || !this.t7.netStatus.connected)
             return
+        document.title = `Terminal 7: ${this.name}`
         // if we're already boarding, just focus
         if (this.session) {
             // TODO: check session's status

--- a/src/terminal7.js
+++ b/src/terminal7.js
@@ -584,6 +584,7 @@ peer_name = "${peername}"\n`
         document.querySelectorAll(".pane-buttons").forEach(
             e => e.classList.add("off"))
         window.location.href = "#home"
+        document.title = "Terminal 7"
     }
     /* 
      * Terminal7.logDisplay display or hides the notifications.

--- a/src/window.js
+++ b/src/window.js
@@ -29,7 +29,7 @@ export class Window {
     open(e) {
         this.e = document.createElement('div')
         this.e.className = "window"
-        this.e.id = `tab-${this.gate.id}.${this.id}`
+        this.e.id = `${this.gate.name}.${this.id+1}`
         e.appendChild(this.e)
 
         // Add the name with link to tab bar
@@ -67,7 +67,6 @@ export class Window {
             this.e.classList.remove("hidden")
         this.nameE.classList.add("on")
         this.gate.activeW = this
-        window.location.href=`#tab-${this.gate.id}.${this.id+1}`
         if (this.activeP)
             this.activeP.focus()
     }

--- a/src/window.js
+++ b/src/window.js
@@ -29,7 +29,7 @@ export class Window {
     open(e) {
         this.e = document.createElement('div')
         this.e.className = "window"
-        this.e.id = `${this.gate.name}.${this.id+1}`
+        this.e.id = `tab-${this.gate.id}.${this.id}`
         e.appendChild(this.e)
 
         // Add the name with link to tab bar

--- a/src/window.js
+++ b/src/window.js
@@ -36,7 +36,6 @@ export class Window {
         let a = document.createElement('a')
         a.id = this.e.id+'-name'
         a.w = this
-        a.setAttribute('href', `#${this.e.id}`)
         a.innerHTML = this.name
         // Add gestures on the window name for rename and drag to trash
         let h = new Hammer.Manager(a, {})


### PR DESCRIPTION
The URL now includes the connected gate's name, and the IDs of the active window and pane, closes #173 .
The HTML title now changes to `Terminal7: <hostname>` when connected, closes #189.

The URL template is `#pane-<pane>`.