### PR TITLE
Displaying changelog directly in place

### DIFF
--- a/css/terminal7.css
+++ b/css/terminal7.css
@@ -372,6 +372,7 @@ button.rename-close {
 }
 #version a {
     text-decoration: underline;
+	cursor: pointer;
 }
 #version footer {
     font-size: 10px;
@@ -695,4 +696,32 @@ audio { display: none; }
 button.boarding  {
     font-weight: bold;
     text-shadow: var(--remote-border) 1px 0 10px;
+}
+#changelog {
+	visibility: hidden;
+	max-width: 0;
+	max-height: 0;
+	padding: 0 1em;
+	line-height: 1.5em;
+	overflow-x: hidden;
+	overflow-y: scroll;
+	transition: all 0.5s ease;
+	background-color: var(--text-background);
+	border-radius: 5px;
+}
+#changelog.show {
+	visibility: visible;
+	max-width: 30vw;
+	max-height: 60vh;
+}
+#changelog::-webkit-scrollbar-thumb {
+    background: var(--text-color);
+    border-radius: 5px;
+}
+#changelog::-webkit-scrollbar-track {
+    background: var(--text-background);
+    border-radius: 5px;
+}
+#changelog::-webkit-scrollbar {
+    height: 14px;
 }

--- a/css/terminal7.css
+++ b/css/terminal7.css
@@ -699,7 +699,8 @@ button.boarding  {
 }
 #changelog {
 	visibility: hidden;
-	max-width: 0;
+	position: relative;
+	max-width: 10vw;
 	max-height: 0;
 	padding: 0 1em;
 	line-height: 1.5em;
@@ -724,4 +725,10 @@ button.boarding  {
 }
 #changelog::-webkit-scrollbar {
     height: 14px;
+}
+#changelog>a {
+	position: absolute;
+	top: 3%;
+	right: 2%;
+	text-decoration: none;
 }

--- a/index.html
+++ b/index.html
@@ -32,20 +32,18 @@
              </div>
              <div class="line-break"></div>
           </div>
-          <div id="version">
-              <h1>Terminal 7</h1>
-              <p><a href="https://github.com/tuzig/terminal7/blob/master/CHANGELOG.md"
-                  target="_blank">
-                  version 1.0-rc.3
-              </a></p>
-              <footer>map inspired by Eero Saarinen's T5</footer>
-          </div>
           <div id="map-footer">
               <div class="empty-pad"><div></div></div>
               <div class="empty-pad"><div></div></div>
               <div class="empty-pad"><div></div></div>
               <div class="empty-pad"><div></div></div>
              <div class="line-break"></div>
+          </div>
+          <div id="version">
+              <h1>Terminal 7</h1>
+              <p><a id="toggle-changelog">version 1.0-rc.3</a></p>
+			  <div id="changelog"></div>
+              <footer>map inspired by Eero Saarinen's T5</footer>
           </div>
       </div>
       <div id="manual-install" class="hidden modal border">
@@ -169,7 +167,7 @@
               With copy mode you can search, mark and copy text from
               the active pane's buffer.
           </p>
-          <div class="keys-help">
+   <div class="keys-help">
           <table><tbody>
         <tr> <td>Move</td> <td>hjkl &larr;&uarr;&darr;&rarr;</td> </tr>
         <tr> <td>Mark</td> <td>Space</td> </tr>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,12 @@
           <div id="version">
               <h1>Terminal 7</h1>
               <p><a id="toggle-changelog">version 1.0-rc.3</a></p>
-			  <div id="changelog"></div>
+			  <div id="changelog">
+				  <a href="https://github.com/tuzig/terminal7/blob/master/CHANGELOG.md" target="_blank">
+					  <i class="f7-icons">logo_github</i>
+				  </a>
+				  <div id="changelog-content"></div>
+			  </div>
               <footer>map inspired by Eero Saarinen's T5</footer>
           </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
     "@tuzig/codemirror": "5.65.5-mods",
     "@tuzig/toml": "^3.0.0-browser",
     "@tuzig/xterm": "4.18.0-decoration",
+    "@types/marked": "^4.0.7",
     "capacitor-ssh-plugin": "<2",
     "glob": "<8",
     "hammerjs": "<3",
     "idb": "<7",
+    "marked": "^4.1.0",
     "uuid": "^8.3.2",
     "xterm-addon-fit": "^0.5.0",
     "xterm-addon-search": "^0.7.0",
@@ -96,15 +98,26 @@
     "env": {
       "browser": true
     },
-	"globals": {
-	  "db": true,
-	  "terminal7": true
-	},
-	"ignorePatterns": ["src/imageMapResizer.js"],
-	"rules": {
-		"no-empty": ["error", { "allowEmptyCatch": true }],
-		"no-constant-condition": ["error", { "checkLoops": false }]
-	}
+    "globals": {
+      "db": true,
+      "terminal7": true
+    },
+    "ignorePatterns": [
+      "src/imageMapResizer.js"
+    ],
+    "rules": {
+      "no-empty": [
+        "error",
+        {
+          "allowEmptyCatch": true
+        }
+      ],
+      "no-constant-condition": [
+        "error",
+        {
+          "checkLoops": false
+        }
+      ]
+    }
   }
 }
-

--- a/src/terminal7.js
+++ b/src/terminal7.js
@@ -132,6 +132,8 @@ export class Terminal7 {
         }
         this.loadConf(d)
 
+		this.loadChangelog()
+
         // buttons
         document.getElementById("trash-button")
                 .addEventListener("click",
@@ -1050,14 +1052,13 @@ peer_name = "${peername}"\n`
 	async loadChangelog() {
 		const resp = await fetch("CHANGELOG.md")
 		const changelog = await resp.text()
-		const e = document.getElementById("changelog")
+		const e = document.getElementById("changelog-content")
 		e.innerHTML = marked.parse(changelog)
+		e.querySelectorAll("[id]").forEach(e => e.id = "changelog-" + e.id) // add prefix to all ids to avoid conflicts
 		e.querySelectorAll("a").forEach(a => a.target = "_blank")
 	}
 	toggleChangelog() {
 		const e = document.getElementById("changelog")
-		if (!e.innerHTML)
-			this.loadChangelog()
 		e.classList.toggle("show")
 	}
 }

--- a/src/terminal7.js
+++ b/src/terminal7.js
@@ -17,6 +17,7 @@ import { tomlMode} from '@tuzig/codemirror/mode/toml/toml.js'
 import { dialogAddOn } from '@tuzig/codemirror/addon/dialog/dialog.js'
 import { formatDate } from './utils.js'
 import { openDB } from 'idb'
+import { marked } from 'marked'
 
 import { Capacitor } from '@capacitor/core'
 import { App } from '@capacitor/app'
@@ -165,6 +166,8 @@ export class Terminal7 {
                 setTimeout(() => this.connect(), 50)
                 ev.stopPropagation()
             })
+		document.getElementById('toggle-changelog')
+				.addEventListener('click', () => this.toggleChangelog())
         // hide the modal on xmark click
         // Handle network events for the indicator
         Network.addListener('networkStatusChange', s => 
@@ -1043,4 +1046,17 @@ peer_name = "${peername}"\n`
             })
         })
     }
+	async loadChangelog() {
+		const resp = await fetch("CHANGELOG.md")
+		const changelog = await resp.text()
+		const e = document.getElementById("changelog")
+		e.innerHTML = marked.parse(changelog)
+		e.querySelectorAll("a").forEach(a => a.target = "_blank")
+	}
+	toggleChangelog() {
+		const e = document.getElementById("changelog")
+		if (!e.innerHTML)
+			this.loadChangelog()
+		e.classList.toggle("show")
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,6 +1300,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/marked@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.7.tgz#400a76809fd08c2bbd9e25f3be06ea38c8e0a1d3"
+  integrity sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==
+
 "@types/node@*":
   version "18.6.3"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz"
@@ -3287,6 +3292,11 @@ magic-string@^0.25.0, magic-string@^0.25.7:
   integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
   dependencies:
     sourcemap-codec "^1.4.8"
+
+marked@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.1.0.tgz#3fc6e7485f21c1ca5d6ec4a39de820e146954796"
+  integrity sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Closes #140.
Using [marked](/markedjs/marked) I converted the `CHANGELOG.md` file to HTML directly - hope it works in the compiled app too.