### PR TITLE
Having links open in default browser

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -38,7 +38,7 @@ export class T7Map {
             const e = document.getElementById("t0")
             this.fitAddon = new FitAddon()
             const webLinksAddon = new WebLinksAddon((MouseEvent, url) => {
-                Browser.open({ url })
+                window.open(url, "_blank", "noopener")
             })
             this.t0.loadAddon(webLinksAddon)
             this.t0.loadAddon(this.fitAddon)

--- a/src/pane.js
+++ b/src/pane.js
@@ -78,7 +78,7 @@ export class Pane extends Cell {
         this.fitAddon = new FitAddon()
         this.searchAddon = new SearchAddon()
         this.WebLinksAddon = new WebLinksAddon((MouseEvent, url) => {
-            Browser.open({ url })
+            window.open(url, "_blank", "noopener")
         })
 
         // there's a container div we need to get xtermjs to fit properly


### PR DESCRIPTION
Closes #313.
Needs testing on the iPad - a similar method didn't work back in #235, but I found [a StackOverflow thread](https://stackoverflow.com/questions/40593632/use-window-open-but-block-use-of-window-opener) with a simple fix. Please test it on an iPad and let me know what happens (on PC it obviously works well).