### PR TITLE
Adding tab switching command

### DIFF
--- a/src/pane.js
+++ b/src/pane.js
@@ -419,7 +419,7 @@ export class Pane extends Cell {
         case "-":
             f = () => this.scale(-1)
             break
-        case "5":
+        case "\\":
             f = () => this.split("topbottom")
             break
         case "'":
@@ -455,8 +455,12 @@ export class Pane extends Cell {
         case "ArrowDown":
             f = () => this.w.moveFocus("down")
             break
-        case "9":
+        case "p":
             f = () => this.t7.dumpLog()
+            break
+        default:
+            if (ev.key >= "1" && ev.key <= "9")
+                this.gate.windows[ev.key - 1].focus()
             break
         }
 


### PR DESCRIPTION
Resolves #331.
Changed v-split to `\` (near `'` which is h-split and also the `|` key).
For now log dumping is `p` since 0 is already used for resetting the font size, let me know if you want it changed.