### PR TITLE
Fixing title overflowing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,10 +3,9 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]

--- a/css/terminal7.css
+++ b/css/terminal7.css
@@ -745,6 +745,18 @@ button.boarding  {
 	right: 2%;
 	text-decoration: none;
 }
+#title-short {
+  display: none;
+  letter-spacing: 0.1em;
+}
+@media (max-width: 600px) {
+    #title-short {
+        display: block;
+    }
+    #title-long {
+        display: none;
+    }
+}
 .expand-gate {
     display: block;
     float:right;

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
              <div class="line-break"></div>
           </div>
           <div id="version">
-              <h1>Terminal 7</h1>
+              <h1 id="title-long">Terminal 7</h1>
+              <h1 id="title-short">T7</h1>
               <p><a id="toggle-changelog">version 1.4.2</a></p>
 			  <div id="changelog">
 				  <a href="https://github.com/tuzig/terminal7/blob/master/CHANGELOG.md" target="_blank">
@@ -121,7 +122,7 @@
           <!--
         <p>
         Welcome to our beta. To start using Terminal7 you will need a server
-        with the webexec program running. You can use any *Nix machine as your 
+        with the webexec program running. You can use any *Nix machine as your
         server. Installation is prety simple, just follow the
         <a href="https://github.com/tuzig/webexec/#install">instructions</a>.
         </p> -->
@@ -131,7 +132,7 @@
           peerbook helps with fingerprints exchange,
           ephermal IP hosts and behind-the-NAT servers.
         </p><p>
-          Regsiter to get your peerbook and help us test the service: 
+          Regsiter to get your peerbook and help us test the service:
         </p>
           <nav>
               <button type="button" class="close"><i class="f7-icons">
@@ -208,7 +209,7 @@
        <div class="lose-state modal border temporal">
           <h1 class="warning">Lost Layout & Shells</h1>
           <h3>vanilla SSH has no session memory</h3>
-          <p>To keep state while switching apps, T7 needs its backend - 
+          <p>To keep state while switching apps, T7 needs its backend -
           <a href="https://github.com/tuzig/webexec">webexec</a>. webexec is a real time
           terminal running over WebRTC written in Go.
           </p>


### PR DESCRIPTION
Fixes #362.
I added a media query so that Terminal 7 changes to T7 on narrow displays.